### PR TITLE
Test on Python 3.6 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: python
 cache: pip
 python:
     - 2.7
+    - 3.6
 matrix:
     allow_failures:
+        - python: 3.6
         - python: nightly
         - python: pypy
         - python: pypy3


### PR DESCRIPTION
Flake8 [finds different errors](http://flake8.pycqa.org/en/latest/user/invocation.html) on Python 2 and Python 3.  In general, if code passes on Python 3 then it will probably pass on Python 2 as well.  But the opposite is not true.  My recommendation would be that you run on both Python 2 and 3 just to be sure or that you run on Python 3 only.  Here we have set Python 3 testing to run in __allow_failures__ mode so that we can see the open issues but the overall test will still be green.

https://travis-ci.org/kezhenxu94/house-renting/builds/385662266